### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sfuhrm/saphir-hash/security/code-scanning/2](https://github.com/sfuhrm/saphir-hash/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/maven.yml`, directly under `on:` triggers (or before `jobs:`). For this workflow, the best minimal permission is:

- `contents: read`

This preserves existing behavior (checkout/build/upload artifacts) while ensuring the token is not granted broader default write access. No imports, methods, or additional definitions are needed—just YAML configuration in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
