### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Potential fix for [https://github.com/sfuhrm/saphir-hash/security/code-scanning/1](https://github.com/sfuhrm/saphir-hash/security/code-scanning/1)

Add an explicit `permissions` block for the `build` job so the token gets only what this job needs.  
For this workflow, the job checks out code, builds artifacts, and creates/uploads GitHub Releases assets. That requires:

- `contents: write` (needed to create a release and upload release assets)
- no additional scopes are required for shown steps

Best fix with no functional change: insert `permissions:` under `jobs.build` (same indentation level as `runs-on`, `outputs`, `env`, `steps`) and set `contents: write`. This preserves current release functionality while explicitly constraining token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
